### PR TITLE
Set auto-mode-alist at top-level and Add autoload cookie

### DIFF
--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -184,11 +184,12 @@ The variable nginx-indent-level controls the amount of indentation.
 
   (set (make-local-variable 'font-lock-defaults)
        '(nginx-font-lock-keywords nil))
-  (run-hooks 'nginx-mode-hook)
+  (run-hooks 'nginx-mode-hook))
 
-  (add-to-list 'auto-mode-alist
-               '("nginx\.conf$"  . nginx-mode)
-               '("/etc/nginx/.*" . nginx-mode)))
+;;;###autoload
+(add-to-list 'auto-mode-alist
+             '("nginx\.conf$"  . nginx-mode)
+             '("/etc/nginx/.*" . nginx-mode))
 
 (provide 'nginx-mode)
 


### PR DESCRIPTION
This commit ensures that users who have installed `nginx-mode` from [MELPA](http://melpa.milkbox.net/) will be able to automatically turn on `nginx-mode` when visiting a `ngix.conf` or `/etc/nginx/.*` file without explicitly requiring the library first. For information about this fix, See [Packaging-Basics](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html).
