### PR TITLE
fixed auto-mode-alist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ Put this file into your `load-path` and the following into your `~/.emacs`:
   (require 'nginx-mode)
 ```
 
-The mode should automatically activate for files:
+The mode automatically activates for:
 
-1. Called `nginx.conf`
+1. Files, called `nginx.conf`
 2. Files ending in `.conf` under `nginx` directory
-3. All files in `nginx/sites-available` and `nginx/sites-enabled`
 
-If this does not work (e.g. shadowed by other packages autoload entries), this also goes to `~/.emacs`:
+If you want `sites-enabled` dir, add this to `~/.emacs` (not done by
+default, because can be shadowed by `apache-mode`):
 
 ```lisp
-(add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
-(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
 (add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
 ```

--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -187,9 +187,7 @@ The variable nginx-indent-level controls the amount of indentation.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
+(add-to-list 'auto-mode-alist '("/nginx/.+\\.conf\\'" . nginx-mode))
 
 (provide 'nginx-mode)
 


### PR DESCRIPTION
This code:

``` lisp
(add-to-list 'auto-mode-alist
 '("nginx\.conf$" . nginx-mode)
 '("/etc/nginx/.*" . nginx-mode))
```

was broken in two ways:
1. wrong regexps
2. wrong `add-to-list` syntax: the third argument is `append`, not an additional item.

Changed the auto-mode-alist part so it works now (slightly changed the actual regexps, reflected this in docs, users are likely not to notice this at all).
