### PR TITLE
fixed auto-mode-alist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Licensed under the [GPL version 3](http://www.gnu.org/licenses/) or later.
 This is a quick mode for editing Nginx config files, as I didn't find
 anything else around that did quite this much.
 
-Many thanks to the authors of puppet-mode.el, from where I found a
+Many thanks to the authors of `puppet-mode.el`, from where I found a
 useful indentation function that I've modified to suit this situation.
 
-Put this file into your load-path and the following into your `~/.emacs`:
+Put this file into your `load-path` and the following into your `~/.emacs`:
 ```lisp
   (require 'nginx-mode)
 ```

--- a/README.md
+++ b/README.md
@@ -19,12 +19,21 @@ anything else around that did quite this much.
 Many thanks to the authors of puppet-mode.el, from where I found a
 useful indentation function that I've modified to suit this situation.
 
-Put this file into your load-path and the following into your ~/.emacs:
+Put this file into your load-path and the following into your `~/.emacs`:
 ```lisp
   (require 'nginx-mode)
 ```
 
-The mode should automatically activate for files called `nginx.conf` and files under `/etc/nginx` - if not, you can add something like this to your init file:
+The mode should automatically activate for files:
+
+1. Called `nginx.conf`
+2. Files ending in `.conf` under `nginx` directory
+3. All files in `nginx/sites-available` and `nginx/sites-enabled`
+
+If this does not work (e.g. shadowed by other packages autoload entries), this also goes to `~/.emacs`:
+
 ```lisp
-(add-to-list 'auto-mode-alist '("/etc/nginx/sites-available/.*" . nginx-mode))   
+(add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
+(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
+(add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
 ```

--- a/README.md
+++ b/README.md
@@ -24,16 +24,14 @@ Put this file into your `load-path` and the following into your `~/.emacs`:
   (require 'nginx-mode)
 ```
 
-The mode should automatically activate for files:
+The mode automatically activates for:
 
-1. Called `nginx.conf`
+1. Files, called `nginx.conf`
 2. Files ending in `.conf` under `nginx` directory
-3. All files in `nginx/sites-available` and `nginx/sites-enabled`
 
-If this does not work (e.g. shadowed by other packages autoload entries), this also goes to `~/.emacs`:
+If you want `sites-enabled` dir, add this to `~/.emacs` (not done by
+default, because can be shadowed by `apache-mode`):
 
 ```lisp
-(add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
-(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
 (add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
 ```

--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -185,9 +185,11 @@ The variable nginx-indent-level controls the amount of indentation.
   (run-hooks 'nginx-mode-hook))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             '("nginx\.conf$"  . nginx-mode)
-             '("/etc/nginx/.*" . nginx-mode))
+(add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
 
 (provide 'nginx-mode)
 

--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -187,9 +187,7 @@ The variable nginx-indent-level controls the amount of indentation.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("/nginx/.*\\.conf\\'" . nginx-mode))
-;;;###autoload
-(add-to-list 'auto-mode-alist '("/nginx/sites-\\(?:available\\|enabled\\)/" . nginx-mode))
+(add-to-list 'auto-mode-alist '("/nginx/.+\\.conf\\'" . nginx-mode))
 
 (provide 'nginx-mode)
 


### PR DESCRIPTION
This code:

```lisp
(add-to-list 'auto-mode-alist
 '("nginx\.conf$" . nginx-mode)
 '("/etc/nginx/.*" . nginx-mode))
```

was broken in two ways:

1. wrong regexps
2. wrong add-to-list syntax: the third argument is append, not an additional item.

Changed the `auto-mode-alist` part so it works now, but only for `*/nginx/*.conf` and `nginx.conf`.

Sites-enabled stuff should be disabled by default: clashes with `apache-mode` (mentioned this in docs).

Adding of all files under `/etc/nginx` is evil (they're not necessarily nginx configs actually), so disabled that as well.
