### PR TITLE
Remove `run-hook`, it is run automatically.

### DIFF
--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -184,8 +184,7 @@ The variable nginx-indent-level controls the amount of indentation.
   (set (make-local-variable 'paragraph-separate) "\\([ 	\f]*\\|#\\)$")
 
   (set (make-local-variable 'font-lock-defaults)
-       '(nginx-font-lock-keywords nil))
-  (run-hooks 'nginx-mode-hook))
+       '(nginx-font-lock-keywords nil)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))


### PR DESCRIPTION
Hi.

When using `define-derived-mode` one doesn't need (and shouldn't) use `run-hook` because the macro adds the form `run-mode-hook` itself when expanded (use macroexpand to check!).

This results in the hook being called twice, see

```elisp
(defun my-nginx-mode-init ()
  (message "Hello"))
(add-hook 'nginx-mode-hook 'my-nginx-mode-init)
```

In messages I have

    Hello [2 times]

Simply removing the form and using the one provided by the macro is enough to fix this.