### PR TITLE
Add top-level Nginx configuration blocks to magic-fallback-mode-alist.

### DIFF
--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -190,6 +190,11 @@ The variable nginx-indent-level controls the amount of indentation.
 (add-to-list 'auto-mode-alist '("nginx\\.conf\\'"  . nginx-mode))
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("/nginx/.+\\.conf\\'" . nginx-mode))
+;;;###autoload
+(add-to-list
+ 'magic-fallback-mode-alist
+ '("\\(?:.*\n\\)*\\(?:http\\|server\\|location .+\\|upstream .+\\)[ \n\t]+{"
+   . nginx-mode))
 
 (provide 'nginx-mode)
 


### PR DESCRIPTION
As mentioned in issue #6, Nginx configuration today is often edited
indirectly as part of a CMS, and the files are often fragments rather
than a single nginx.conf.

By adding the common top-level blocks to a magic mode alist, we can
still automatically detect these files. By choosing the fallback
alist, we still allow other major modes to make a stronger claim based
on extension or literal content / interpreter match.