### PR TITLE
Allow anything to follow a closing brace at start of line

### DIFF
--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -112,7 +112,7 @@ of the closing brace of a block."
           (block-indent (nginx-block-indent))
           cur-indent)
       (cond
-       ((and (looking-at "^\\s-*}\\s-*$") block-indent)
+       ((and (looking-at "^\\s-*}") block-indent)
         ;; This line contains a closing brace and we're at the inner
         ;; block, so we should indent it matching the indentation of
         ;; the opening brace of the block.


### PR DESCRIPTION
Specifically this fixes an indentation issue with this:

    if ($host = example.com) {
        return 301 https://$host$request_uri;
    } # managed by Certbot

Before this change this would have been indented as:

    if ($host = example.com) {
        return 301 https://$host$request_uri;
        } # managed by Certbot

Because the regular expression was looking for a ‘}’ with nothing following it, but comments can follow this construct just fine.