### PR TITLE
Fix indentation of closing braces

### DIFF
--- a/nginx-mode.el
+++ b/nginx-mode.el
@@ -76,24 +76,8 @@
   "If point is in a block, return the indentation of the first line of that
 block (the line containing the opening brace).  Used to set the indentation
 of the closing brace of a block."
-  (save-excursion
-    (save-match-data
-      (let ((opoint (point))
-            (apoint (search-backward "{" nil t)))
-        (when apoint
-          ;; This is a bit of a hack and doesn't allow for strings.  We really
-          ;; want to parse by sexps at some point.
-          (let ((close-braces (count-matches "}" apoint opoint))
-                (open-braces 0))
-            (while (and apoint (> close-braces open-braces))
-              (setq apoint (search-backward "{" nil t))
-              (when apoint
-                (setq close-braces (count-matches "}" apoint opoint))
-                (setq open-braces (1+ open-braces)))))
-          (if apoint
-              (current-indentation)
-            nil))))))
-
+  (* (syntax-ppss-depth (syntax-ppss))
+     nginx-indent-level))
 
 (defun nginx-comment-line-p ()
   "Return non-nil iff this line is a comment."
@@ -116,7 +100,7 @@ of the closing brace of a block."
         ;; This line contains a closing brace and we're at the inner
         ;; block, so we should indent it matching the indentation of
         ;; the opening brace of the block.
-        (setq cur-indent block-indent))
+        (setq cur-indent (- block-indent nginx-indent-level)))
        (t
         ;; Otherwise, we did not start on a block-ending-only line.
         (save-excursion


### PR DESCRIPTION
The ‘nginx-indent-block’ function would get confused by braces in comments. Here is an example of how indentation could go wrong:

    server {
        # some comment with {
        # ...
        }

After this change the example is correctly indented:

    server {
        # some comment with {
        # ...
    }